### PR TITLE
Update README browser support list for Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ intersectionObserverAdmin.destroy();
     </tr>
     <tr>
         <td>Safari</td>
-        <td>Safari Technology Preview</td>
+        <td>12.1</td>
     </tr>
     <tr>
         <td>Chrome for Android</td>


### PR DESCRIPTION
Safari added full feature support for `IntersectionObserver` in 12.1, in March 2019, so replace "Safari Tech Preview" with "12.1" in the table.