### PR TITLE
[Typescript]: update threshold typing to allow for number and array of numbers in the IOptions interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import Registry from './registry';
 export interface IOptions {
   root?: HTMLElement;
   rootMargin?: string;
-  threshold?: number;
+  threshold?: number | number[];
   [key: string]: any;
 }
 


### PR DESCRIPTION
This PR updates the typing for `threshold` within the `IOptions` interface as the browser IntersectionObserver API allows threshold to be a number as well as an array of numbers.