### PR TITLE
fix leak by releasing ref to observed element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export interface IOptions {
 }
 
 type StateForRoot = {
-  elements: [HTMLElement];
+  elements: HTMLElement[];
   options: IOptions;
   intersectionObserver: any;
 };
@@ -61,6 +61,11 @@ export default class IntersectionObserverAdmin extends Notifications {
     if (matchingRootEntry) {
       const { intersectionObserver } = matchingRootEntry;
       intersectionObserver.unobserve(target);
+
+      const elIndex = matchingRootEntry.elements.indexOf(target);
+      if (elIndex !== -1) {
+        matchingRootEntry.elements.splice(elIndex, 1);
+      }
     }
   }
 


### PR DESCRIPTION
We add an observed element to `elements` array every time we call `.observe()` however we don't remove the observed element from `elements` array when we call `.unobserve()`.

this leads to memory leaks in cases e.g. when we render component and use `{{in-viewport}}` modifier and then destroy component - reference to the observed element would be held up