### PR TITLE
feat(memory-leaks): remove elements from registries when unobserve is called 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export default class IntersectionObserverAdmin extends Notifications {
     if (matchingRootEntry) {
       const { intersectionObserver } = matchingRootEntry;
       intersectionObserver.unobserve(target);
+      this.removeElement(target);
     }
   }
 
@@ -121,6 +122,32 @@ export default class IntersectionObserverAdmin extends Notifications {
   }
 
   /**
+   * cleanup removes provided elements from both registries
+   *
+   * @method removeElement
+   * @public
+   *
+   */
+  public removeElement(element: HTMLElement | Window): void {
+    this.removeElementNotification(element);
+    this.elementRegistry.removeElement(element);
+  }
+
+  /**
+   * checks whether element exists in either registry
+   *
+   * @method elementExists
+   * @public
+   *
+   */
+  public elementExists(element: HTMLElement | Window): boolean {
+    return Boolean(
+      this.elementNotificationExists(element) ||
+        this.elementRegistry.elementExists(element)
+    );
+  }
+
+  /**
    * use function composition to curry options
    *
    * @method setupOnIntersection
@@ -177,7 +204,7 @@ export default class IntersectionObserverAdmin extends Notifications {
         // if share same root and need to add new entry to root match
         // not functional but :shrug
         potentialRootMatch[stringifiedOptions] = observerEntry;
-      } else {
+      } else if (!this.elementRegistry.elementExists(root)) {
         // no root exists, so add to WeakMap
         this.elementRegistry.addElement(root, {
           [stringifiedOptions]: observerEntry

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -38,6 +38,14 @@ export default abstract class Notifications {
     );
   }
 
+  public removeElementNotification(element: HTMLElement | Window) {
+    this.registry.removeElement(element);
+  }
+  
+  public elementNotificationExists(element: HTMLElement | Window): boolean {
+    return Boolean(this.registry.elementExists(element));
+  }
+
   /**
    * @hidden
    * Executes registered callbacks for key.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,27 @@
 import IntersectionObserverAdmin from '../src/index';
 
+class IntersectionObserver {
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+
+  disconnect() {
+    return null;
+  }
+
+  observe() {
+    return null;
+  }
+
+  takeRecords() {
+    return [];
+  }
+
+  unobserve() {
+    return null;
+  }
+}
+
 describe('add entry', () => {
   it('observe exists', () => {
     const el = document.createElement('div');
@@ -15,5 +37,44 @@ describe('add entry', () => {
     expect(ioAdmin.addExitCallback).toBeDefined();
     expect(ioAdmin.dispatchEnterCallback).toBeDefined();
     expect(ioAdmin.dispatchExitCallback).toBeDefined();
+  });
+});
+
+describe('elements', () => {
+  beforeEach(() => {
+    globalThis.IntersectionObserver = IntersectionObserver;
+  });
+
+  it('observe', () => {
+    const el_1 = document.createElement('div');
+    const el_2 = document.createElement('div');
+    const el_3 = document.createElement('div');
+    const ioAdmin = new IntersectionObserverAdmin();
+
+    ioAdmin.observe(el_1);
+    ioAdmin.observe(el_2);
+    ioAdmin.observe(el_3);
+
+    expect(ioAdmin.elementExists(el_1)).toBeTruthy();
+    expect(ioAdmin.elementExists(el_2)).toBeTruthy();
+    expect(ioAdmin.elementExists(el_3)).toBeTruthy();
+  });
+
+  it('unobserve', () => {
+    const el_1 = document.createElement('div');
+    const el_2 = document.createElement('div');
+    const el_3 = document.createElement('div');
+    const ioAdmin = new IntersectionObserverAdmin();
+
+    ioAdmin.observe(el_1);
+    ioAdmin.observe(el_2);
+    ioAdmin.observe(el_3);
+
+    ioAdmin.unobserve(el_1, {});
+    ioAdmin.unobserve(el_3, {});
+
+    expect(ioAdmin.elementExists(el_1)).toBeFalsy();
+    expect(ioAdmin.elementExists(el_2)).toBeTruthy();
+    expect(ioAdmin.elementExists(el_3)).toBeFalsy();
   });
 });


### PR DESCRIPTION
relates to https://github.com/elwayman02/ember-scroll-modifiers/pull/1078

Reopened since I closed https://github.com/snewcomer/intersection-observer-admin/pull/54 by a mistake when syncing the fork.